### PR TITLE
【Fixed】チームリーダーの変更機能の追加

### DIFF
--- a/app/controllers/teams_controller.rb
+++ b/app/controllers/teams_controller.rb
@@ -49,6 +49,7 @@ class TeamsController < ApplicationController
 
   def authority
     if @team.update(team_params)
+      ToBeLeaderMailer.to_be_leader_mail(@team).deliver
       redirect_to @team, notice: I18n.t('views.messages.transfer_authority')
     else
       flash.now[:error] = I18n.t('views.messages.failed_to_transfer_authority')

--- a/app/controllers/teams_controller.rb
+++ b/app/controllers/teams_controller.rb
@@ -1,6 +1,6 @@
 class TeamsController < ApplicationController
   before_action :authenticate_user!
-  before_action :set_team, only: %i[show edit update destroy]
+  before_action :set_team, only: %i[show edit update destroy authority]
 
   def index
     @teams = Team.all
@@ -45,6 +45,15 @@ class TeamsController < ApplicationController
 
   def dashboard
     @team = current_user.keep_team_id ? Team.find(current_user.keep_team_id) : current_user.teams.first
+  end
+
+  def authority
+    if @team.update(team_params)
+      redirect_to @team, notice: I18n.t('views.messages.transfer_authority')
+    else
+      flash.now[:error] = I18n.t('views.messages.failed_to_transfer_authority')
+      render :show
+    end
   end
 
   private

--- a/app/mailers/to_be_leader_mailer.rb
+++ b/app/mailers/to_be_leader_mailer.rb
@@ -1,0 +1,8 @@
+class ToBeLeaderMailer < ApplicationMailer
+  default from: 'from@example.com'
+
+  def to_be_leader_mail(team)
+    @team = team
+    mail to: @team.owner.email, subject: I18n.t('views.messages.edit_team_leader')
+  end
+end

--- a/app/views/teams/show.html.erb
+++ b/app/views/teams/show.html.erb
@@ -42,6 +42,9 @@
                       <td><%= image_tag 'default.jpg', size: '40x40' %></td>
                       <td><%= assign.user.email %></td>
                       <td><%= link_to I18n.t('views.button.delete'), team_assign_path(@team, assign), method: :delete, class: 'btn btn-sm btn-danger' %></td>
+                      <% if current_user.id == @team.owner_id && current_user.id != assign.user.id %>
+                        <td><%= link_to I18n.t('views.button.transfer_authority'), authority_team_path(@team, team: { owner_id: assign.user.id }), method: :patch, class: 'btn btn-sm btn-primary' %></td>
+                      <% end %>
                     </tr>
                   <% end %>
                 </tbody>

--- a/app/views/to_be_leader_mailer/to_be_leader_mail.html.erb
+++ b/app/views/to_be_leader_mailer/to_be_leader_mail.html.erb
@@ -1,0 +1,2 @@
+<h1><%= I18n.t('views.messages.to_be_leader') %></h1>
+<h4><%= I18n.t('views.common.team') %>： <%= @team.name %></h4>

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -1,6 +1,6 @@
 Rails.application.configure do
   # Verifies that versions and hashed value of the package contents in the project's package.json
-  config.webpacker.check_yarn_integrity = true
+  config.webpacker.check_yarn_integrity = false
   # Settings specified here will take precedence over those in config/application.rb.
 
   # In the development environment your application's code is reloaded on

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -219,6 +219,8 @@ ja:
       failed_to_save_team: '保存に失敗しました、、'
       update_team: 'チーム更新に成功しました！'
       delete_team: 'チーム削除に成功しました！'
+      transfer_authority: 'チームリーダーを変更しました！'
+      failed_to_transfer_authority: 'チームリーダーの変更に失敗しました、、'
       update_profile: 'プロフィールを編集しました！'
       complete_registration: '登録完了'
       edit_article: '記事を編集する'
@@ -257,6 +259,7 @@ ja:
       delete: '削除'
       create: '作成'
       invite: '招待'
+      transfer_authority: '権限移動'
     top:
       line1: 'このアプリケーションは、チームごと、議題ごとに別れて'
       line2: '特定のイシュー（議題）をメンバーで見やすく共有するためのアプリケーションです'

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -223,6 +223,8 @@ ja:
       failed_to_transfer_authority: 'チームリーダーの変更に失敗しました、、'
       update_profile: 'プロフィールを編集しました！'
       complete_registration: '登録完了'
+      edit_team_leader: 'チームリーダーの変更'
+      to_be_leader: 'チームリーダーに任命されました！'
       edit_article: '記事を編集する'
       input_title: '記事タイトルを入力してください'
       input_content: '内容を入力してください'

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -16,6 +16,7 @@ Rails.application.routes.draw do
         resources :comments
       end
     end
+    patch :authority, on: :member
   end
 
   mount LetterOpenerWeb::Engine, at: "/letter_opener" if Rails.env.development?

--- a/spec/mailers/previews/to_be_leader_mailer_preview.rb
+++ b/spec/mailers/previews/to_be_leader_mailer_preview.rb
@@ -1,0 +1,4 @@
+# Preview all emails at http://localhost:3000/rails/mailers/to_be_leader_mailer
+class ToBeLeaderMailerPreview < ActionMailer::Preview
+
+end

--- a/spec/mailers/to_be_leader_mailer_spec.rb
+++ b/spec/mailers/to_be_leader_mailer_spec.rb
@@ -1,0 +1,5 @@
+require "rails_helper"
+
+RSpec.describe ToBeLeaderMailer, type: :mailer do
+  pending "add some examples to (or delete) #{__FILE__}"
+end


### PR DESCRIPTION
#65

・Teamリーダーが他のメンバーにリーダー権限を譲渡する機能を追加
・Teamリーダーが変更された場合、任命されたユーザーに通知メールを送る機能を追加